### PR TITLE
add adaptivity for documents list

### DIFF
--- a/src/frontend/src/components/Document/Document.scss
+++ b/src/frontend/src/components/Document/Document.scss
@@ -6,8 +6,9 @@
   border-radius: 2px;
   padding: 20px 16px;
   width: calc(100vw / 5 - (3 * 0.5em));
+  min-width: 200px;
+  max-width: 300px;
   height: 88px;
-  float: left;
   margin: 0.5em;
   position: relative;
 


### PR DESCRIPTION
for issue #10 

I setted max and min width for doc items and this just works without media queries

<img width="425" alt="image" src="https://user-images.githubusercontent.com/20739202/66701749-83e73600-ed08-11e9-9652-67e8652c8d28.png">
<img width="691" alt="image" src="https://user-images.githubusercontent.com/20739202/66701756-91042500-ed08-11e9-895a-6055e5a1a59e.png">
