### PR TITLE
#10 : Add rules to CSS to make document list adaptive

### DIFF
--- a/src/frontend/src/components/Document/Document.scss
+++ b/src/frontend/src/components/Document/Document.scss
@@ -66,3 +66,9 @@
     background: $HEADER_PANEL_COLOR;
   }
 }
+
+@media screen and (max-width: 820px) {
+  .Document {
+    width: 95%;
+  }
+}

--- a/src/frontend/src/components/DocumentList/DocumentList.js
+++ b/src/frontend/src/components/DocumentList/DocumentList.js
@@ -31,7 +31,7 @@ const DocumentsListFetched = ({
     {documentsList.map(({ title, createdAt, id }, i) => {
       if (!title) return ""
       return (
-        <Link to={"/edit/" + id} key={i}>
+        <Link className={"DocumentWrapper"} to={"/edit/" + id} key={i}>
           <Document
             title={title}
             createdAt={createdAt}

--- a/src/frontend/src/components/DocumentList/DocumentList.scss
+++ b/src/frontend/src/components/DocumentList/DocumentList.scss
@@ -54,3 +54,14 @@
     background: $HIGHLIGHT_COLOR;
   }
 }
+
+
+@media screen and (max-width: 820px) {
+  .DocumentWrapper {
+    width: 100%;
+  }
+  .DocumentList {
+    flex-direction: column-reverse;
+    min-height: 0;
+  }
+}


### PR DESCRIPTION
...to smaller screens. Also, when screen is small it will order all documents in reverse order, so user doesn't need to scroll all way down in order to create new document.